### PR TITLE
Add support for different ports.

### DIFF
--- a/src/com/leapmotion/leap/Controller.as
+++ b/src/com/leapmotion/leap/Controller.as
@@ -134,7 +134,7 @@ package com.leapmotion.leap
 		 * (currently only supported for socket connections).
 		 *
 		 */
-		public function Controller( host:String = null )
+		public function Controller( host:String = null, port : int = 6437 )
 		{
 			leapmotion::listener = new DefaultListener();
 
@@ -144,7 +144,7 @@ package com.leapmotion.leap
 			}
 			else
 			{
-				connection = new LeapSocket( this, host );
+				connection = new LeapSocket( this, host, port );
 			}
 		}
 

--- a/src/com/leapmotion/leap/socket/LeapSocket.as
+++ b/src/com/leapmotion/leap/socket/LeapSocket.as
@@ -66,6 +66,7 @@ package com.leapmotion.leap.socket
 		 * Specifies which host to connect to, default localhost.
 		 */
 		private var host:String = "localhost";
+		private var port:int = 6337;
 
 		/**
 		 * Number of bytes of the handshake response.
@@ -123,11 +124,14 @@ package com.leapmotion.leap.socket
 		 * @param host IP or hostname of the computer running the Leap Motion software.
 		 *
 		 */
-		final public function LeapSocket( _controller:Controller, host:String = null )
+		final public function LeapSocket( _controller:Controller, host:String = null, port : int = 6437 )
 		{
 			if( host )
 				this.host = host;
-
+			
+			if( port )
+				this.port = port;
+			
 			controller = _controller;
 
 			// Generate nonce
@@ -149,7 +153,7 @@ package com.leapmotion.leap.socket
 			socket.addEventListener( IOErrorEvent.IO_ERROR, onIOErrorHandler );
 			socket.addEventListener( SecurityErrorEvent.SECURITY_ERROR, onSecurityErrorHandler );
 			socket.addEventListener( ProgressEvent.SOCKET_DATA, onSocketDataHandler );
-			socket.connect( this.host, 6437 );
+			socket.connect( this.host, this.port );
 			
 			heartBeatTimer.addEventListener( TimerEvent.TIMER, onSendHeartBeatHandler );
 		}
@@ -589,7 +593,7 @@ package com.leapmotion.leap.socket
 		{
 			var text:String = "";
 			text += "GET /v2.json HTTP/1.1\r\n";
-			text += "Host: " + host + ":6437\r\n";
+			text += "Host: " + host + ":" + this.port + "\r\n";
 			text += "Upgrade: websocket\r\n";
 			text += "Connection: Upgrade\r\n";
 			text += "Sec-WebSocket-Key: " + base64nonce + "\r\n";


### PR DESCRIPTION
I'm trying to get multiple Leap Motion devices to work together. I run two separate instances of `leapd` in VMs (so they can both use port 6437) and redirect local ports to each VMs.

To make the devices cooperate, I need to instantiate two `Controller`s with a different port. That's what this pull request is about.
